### PR TITLE
Fix windows build

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -69,13 +69,13 @@ Create a JSON file with the workflow steps:
 ### Adding a workflow
 
 ```bash
-clix add-workflow my-workflow --description "Basic system info workflow" --steps-file workflow.json
+clix flow add my-workflow --description "Basic system info workflow" --steps-file workflow.json
 ```
 
 ### Running a workflow
 
 ```bash
-clix run-workflow my-workflow
+clix flow run my-workflow
 ```
 
 ## Sharing Commands and Workflows
@@ -142,6 +142,6 @@ Create a workflow JSON file:
 Add and run the workflow:
 
 ```bash
-clix add-workflow gcp-troubleshoot --description "GCP service troubleshooting" --steps-file gcp-workflow.json --tags cloud,gcp
-clix run-workflow gcp-troubleshoot
+clix flow add gcp-troubleshoot --description "GCP service troubleshooting" --steps-file gcp-workflow.json --tags cloud,gcp
+clix flow run gcp-troubleshoot
 ```

--- a/src/commands/executor.rs
+++ b/src/commands/executor.rs
@@ -5,7 +5,10 @@ use crate::error::{ClixError, Result};
 use colored::Colorize;
 use std::collections::HashMap;
 use std::io::{self, BufRead, Write};
+#[cfg(unix)]
 use std::os::unix::process::ExitStatusExt;
+#[cfg(windows)]
+use std::os::windows::process::ExitStatusExt;
 use std::process::{Command as ProcessCommand, Output};
 
 pub struct CommandExecutor;

--- a/src/commands/function_converter.rs
+++ b/src/commands/function_converter.rs
@@ -16,10 +16,10 @@ impl FunctionConverter {
     ) -> Result<Workflow> {
         // Read the shell script file
         let content = fs::read_to_string(file_path).map_err(|e| {
-            ClixError::Io(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("Failed to read script file: {}", e),
-            ))
+            ClixError::Io(std::io::Error::other(format!(
+                "Failed to read script file: {}",
+                e
+            )))
         })?;
 
         // Extract the function


### PR DESCRIPTION
## Summary
- silence clippy io-other-error lint in `FunctionConverter`
- fix missing `ExitStatusExt` import on Windows

## Testing
- `cargo nextest run`
- `cargo clippy -- -D warnings`
- `cargo fmt -- --check`
