### PR TITLE
feat: remove flow subcommand and unify command/workflow logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,41 +31,26 @@ cargo install --path .
 
 ## Command Reference
 
-Clix offers a comprehensive set of commands for managing both individual commands and complex workflows. Here's a complete reference of all available commands:
+Clix offers a comprehensive set of commands for managing both individual commands and complex workflows. Commands and workflows are now unified - a command can be a simple single-step operation or a complex multi-step workflow.
 
 ```
 USAGE:
     clix [SUBCOMMAND]
 
 SUBCOMMANDS:
-    add        Add a new command
-    run        Run a stored command
-    list       List all stored commands and workflows
-    remove     Remove a stored command
-    flow       Workflow management commands (see below for subcommands)
-    export     Export commands and workflows to a file
-    import     Import commands and workflows from a file
-    ask        Ask Claude AI for help with creating and running commands
-    settings   Settings management commands (see below for subcommands)
-    git        Git repository management commands (see below for subcommands)
-    help       Print this help message or help for a specific command
-```
-
-Workflow-specific commands:
-
-```
-USAGE:
-    clix flow [SUBCOMMAND]
-
-SUBCOMMANDS:
-    add            Add a new workflow
-    run            Run a stored workflow
-    remove         Remove a stored workflow
-    list           List all stored workflows
-    add-var        Add a variable to a workflow
-    add-profile    Add a profile to a workflow
-    list-profiles  List profiles for a workflow
-    help           Print help for flow or a specific subcommand
+    add           Add a new command or workflow
+    run           Run a stored command or workflow
+    list          List all stored commands and workflows
+    remove        Remove a stored command or workflow
+    add-var       Add a variable to a workflow
+    add-profile   Add a profile to a workflow
+    list-profiles List profiles for a workflow
+    export        Export commands and workflows to a file
+    import        Import commands and workflows from a file
+    ask           Ask Claude AI for help with creating and running commands
+    settings      Settings management commands (see below for subcommands)
+    git           Git repository management commands (see below for subcommands)
+    help          Print this help message or help for a specific command
 ```
 
 Git repository management commands:
@@ -85,29 +70,39 @@ SUBCOMMANDS:
 
 ## Usage
 
-### Adding a command
+### Adding a simple command
 
 ```bash
 clix add my-command --description "Description of the command" --command "echo Hello, World!"
 ```
 
-### Running a command
+### Adding a workflow (multi-step command)
+
+Create a JSON file with workflow steps and add it:
+
+```bash
+clix add my-workflow --description "Description of the workflow" --steps-file workflow.json
+```
+
+### Running a command or workflow
 
 ```bash
 clix run my-command
+# or
+clix run my-workflow
 ```
 
-### Listing commands
+### Listing commands and workflows
 
 ```bash
-# List all commands
+# List all commands and workflows
 clix list
 
 # List commands with a specific tag
 clix list --tag deployment
 ```
 
-### Removing a command
+### Removing a command or workflow
 
 ```bash
 clix remove my-command
@@ -168,7 +163,7 @@ When Claude suggests running a command or creating a new one, you'll be asked fo
 
 ## Working with Workflows
 
-Workflows allow you to define a sequence of steps that are executed in order. Each step can be a regular command or an authentication step that requires user interaction.
+Commands in Clix can be simple single-step operations or complex multi-step workflows. Workflows allow you to define a sequence of steps that are executed in order. Each step can be a regular command or an authentication step that requires user interaction.
 
 ### Creating Workflow Files
 
@@ -230,7 +225,7 @@ Example workflow file (gcloud-workflow.json):
 ]
 ```
 
-### Managing workflows with the `flow` command
+### Managing workflows
 
 #### Adding a workflow
 
@@ -269,33 +264,33 @@ The `step_type` field can be either `Command` or `Auth`:
 Then add the workflow:
 
 ```bash
-clix flow add my-workflow --description "My workflow" --steps-file workflow.json
+clix add my-workflow --description "My workflow" --steps-file workflow.json
 ```
 
 #### Running a workflow
 
 ```bash
 # Run a workflow
-clix flow run my-workflow
+clix run my-workflow
 
 # Run a workflow with specific variable values
-clix flow run my-workflow --var project_name=my-project --var cluster_name=prod-cluster
+clix run my-workflow --var project_name=my-project --var cluster_name=prod-cluster
 
 # Run a workflow using a saved profile
-clix flow run my-workflow --profile prod
+clix run my-workflow --profile prod
 ```
 
 #### Listing workflows
 
 ```bash
-clix flow list
-clix flow list --tag production
+clix list
+clix list --tag production
 ```
 
 #### Removing a workflow
 
 ```bash
-clix flow remove my-workflow
+clix remove my-workflow
 ```
 
 
@@ -334,10 +329,10 @@ You can define variables with descriptions, default values, and requirements to 
 
 ```bash
 # Add a required variable without a default value
-clix flow add-var my-workflow --name cluster_name --description "GKE cluster name" --required
+clix add-var my-workflow --name cluster_name --description "GKE cluster name" --required
 
 # Add an optional variable with a default value
-clix flow add-var my-workflow --name zone --description "GCP zone" --default "us-central1-a" 
+clix add-var my-workflow --name zone --description "GCP zone" --default "us-central1-a" 
 ```
 
 #### Running Workflows with Variables
@@ -346,13 +341,13 @@ There are multiple ways to provide variable values when running a workflow:
 
 ```bash
 # Prompted for variables: You'll be asked for any missing values interactively
-clix flow run my-workflow
+clix run my-workflow
 
 # Command-line variables: Provide values directly in the command
-clix flow run my-workflow --var project_name=my-project --var cluster_name=prod-cluster
+clix run my-workflow --var project_name=my-project --var cluster_name=prod-cluster
 
 # Mixed approach: Provide some values via command line, be prompted for others
-clix flow run my-workflow --var project_name=my-project
+clix run my-workflow --var project_name=my-project
 ```
 
 ### Variable Profiles
@@ -361,27 +356,27 @@ Profiles allow you to save sets of variable values for different environments (l
 
 ```bash
 # Create a production profile
-clix flow add-profile my-workflow --name prod --description "Production environment" \
+clix add-profile my-workflow --name prod --description "Production environment" \
   --var project_name=prod-project \
   --var cluster_name=prod-cluster \
   --var zone=us-central1-a \
   --var namespace=production
 
 # Create a development profile
-clix flow add-profile my-workflow --name dev --description "Development environment" \
+clix add-profile my-workflow --name dev --description "Development environment" \
   --var project_name=dev-project \
   --var cluster_name=dev-cluster \
   --var zone=us-central1-a \
   --var namespace=development
 
 # List all profiles for a workflow
-clix flow list-profiles my-workflow
+clix list-profiles my-workflow
 
 # Run a workflow with a specific profile
-clix flow run my-workflow --profile prod
+clix run my-workflow --profile prod
 
 # Override specific profile values
-clix flow run my-workflow --profile prod --var cluster_name=prod-cluster-2
+clix run my-workflow --profile prod --var cluster_name=prod-cluster-2
 ```
 
 Profiles make it easy to switch between environments without having to remember and type all the variable values each time.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,19 +2,18 @@
 
 ## Short-term Goals
 
-- **AI Integration**: Integrate with AI services to enhance command suggestions and workflow creation
-- **Command Templates**: Add support for parameterized commands with user inputs
 - **Shell Completions**: Generate shell completions for bash, zsh, fish, etc.
-- **Import/Export**: Add functionality to import and export command and workflow collections
 - **Command History**: Track command execution history with timestamps and results
+- **Enhanced Variable Management**: Advanced variable management and templating features
+- **Performance Optimization**: Optimize command and workflow execution performance
 
 ## Medium-term Goals
 
 - **Web Interface**: Create a simple web UI for managing commands and workflows
-- **Sharing Commands**: Enable sharing commands with team members or the community
 - **Remote Execution**: Support for executing commands on remote machines
-- **Environment Management**: Add support for environment variables and secrets
+- **Environment Management**: Enhanced support for environment variables and secrets
 - **Command Scheduling**: Schedule commands and workflows to run at specific times
+- **Advanced Workflow Features**: Loop constructs, error handling, and conditional execution enhancements
 
 ## Long-term Goals
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -65,6 +65,8 @@ clix remove list-files
 
 ## Working with Workflows
 
+Commands in Clix can be simple single-step operations or complex multi-step workflows.
+
 ### Creating a workflow
 
 Create a JSON file with the workflow steps:
@@ -89,13 +91,13 @@ Create a JSON file with the workflow steps:
 ### Adding a workflow
 
 ```bash
-clix flow add my-workflow --description "Basic system info workflow" --steps-file workflow.json
+clix add my-workflow --description "Basic system info workflow" --steps-file workflow.json
 ```
 
 ### Running a workflow
 
 ```bash
-clix flow run my-workflow
+clix run my-workflow
 ```
 
 ## Sharing Commands and Workflows
@@ -162,6 +164,6 @@ Create a workflow JSON file:
 Add and run the workflow:
 
 ```bash
-clix flow add gcp-troubleshoot --description "GCP service troubleshooting" --steps-file gcp-workflow.json --tags cloud,gcp
-clix flow run gcp-troubleshoot
+clix add gcp-troubleshoot --description "GCP service troubleshooting" --steps-file gcp-workflow.json --tags cloud,gcp
+clix run gcp-troubleshoot
 ```

--- a/docs/conditional_workflows.md
+++ b/docs/conditional_workflows.md
@@ -43,7 +43,7 @@ A conditional step executes a block of steps only if a condition is true. It's s
 You can add a conditional step to a workflow using the CLI:
 
 ```bash
-clix flow add-condition my-workflow \
+clix add-condition my-workflow \
   --name "Check Authentication" \
   --description "Check if already authenticated with GCloud" \
   --condition "! gcloud auth application-default print-access-token > /dev/null 2>&1" \
@@ -72,7 +72,7 @@ Where `then_steps.json` contains:
 You can also add an else block that executes when the condition is false:
 
 ```bash
-clix flow add-condition my-workflow \
+clix add-condition my-workflow \
   --name "Check File Exists" \
   --description "Check if config file exists" \
   --condition "[ -f config.yaml ]" \
@@ -132,7 +132,7 @@ Branch steps (similar to switch/case statements) execute different blocks of ste
 You can add a branch step using the CLI:
 
 ```bash
-clix flow add-branch my-workflow \
+clix add-branch my-workflow \
   --name "Set Environment" \
   --description "Configure environment based on parameter" \
   --variable "env" \
@@ -195,7 +195,7 @@ Conditions in Clix support a wide range of expressions:
 You can convert existing shell functions to Clix workflows with conditionals:
 
 ```bash
-clix flow convert-function gke \
+clix convert-function gke \
   --file ~/.zshrc \
   --function gke \
   --description "Switch to a GKE cluster environment" \

--- a/examples/README.md
+++ b/examples/README.md
@@ -28,14 +28,14 @@ Then run it with a specific project ID:
 
 ```bash
 # This will prompt you to replace ${PROJECT_ID} with your actual project ID
-clix run-workflow gcloud-resources
+clix run gcloud-resources
 ```
 
 Or set environment variables before running:
 
 ```bash
 export PROJECT_ID=my-actual-project-id
-clix run-workflow gcloud-resources
+clix run gcloud-resources
 ```
 
 ### Google Cloud Deploy Workflow (`auth-workflow.json`)
@@ -53,7 +53,7 @@ The workflow:
 
 ```bash
 clix import --input examples/auth-workflow.json
-clix run-workflow gcloud-deploy
+clix run gcloud-deploy
 ```
 
 ## Other Examples

--- a/src/ai/claude.rs
+++ b/src/ai/claude.rs
@@ -537,9 +537,20 @@ Follow these guidelines:
         if !command_history.is_empty() {
             prompt.push_str("\nAvailable commands:\n");
             for cmd in command_history {
+                let command_display = if cmd.is_workflow() {
+                    format!(
+                        "Workflow with {} steps",
+                        cmd.steps.as_ref().map_or(0, |s| s.len())
+                    )
+                } else {
+                    cmd.command
+                        .as_ref()
+                        .unwrap_or(&"<no command>".to_string())
+                        .clone()
+                };
                 prompt.push_str(&format!(
                     "- {}: {}\n  Command: {}\n",
-                    cmd.name, cmd.description, cmd.command
+                    cmd.name, cmd.description, command_display
                 ));
             }
         }
@@ -1030,9 +1041,20 @@ Final summary or goodbye message...
         if !command_history.is_empty() {
             prompt.push_str("\nAvailable commands:\n");
             for cmd in command_history {
+                let command_display = if cmd.is_workflow() {
+                    format!(
+                        "Workflow with {} steps",
+                        cmd.steps.as_ref().map_or(0, |s| s.len())
+                    )
+                } else {
+                    cmd.command
+                        .as_ref()
+                        .unwrap_or(&"<no command>".to_string())
+                        .clone()
+                };
                 prompt.push_str(&format!(
                     "- {}: {}\n  Command: {}\n",
-                    cmd.name, cmd.description, cmd.command
+                    cmd.name, cmd.description, command_display
                 ));
             }
         }

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -21,9 +21,23 @@ pub enum Commands {
     /// Remove a stored command
     Remove(RemoveArgs),
 
-    /// Workflow management commands
-    #[command(subcommand)]
-    Flow(FlowCommands),
+    /// Add a variable to a workflow
+    AddVar(AddWorkflowVarArgs),
+
+    /// Add a profile to a workflow
+    AddProfile(AddWorkflowProfileArgs),
+
+    /// List profiles for a workflow
+    ListProfiles(ListWorkflowProfilesArgs),
+
+    /// Add a conditional step to a workflow
+    AddCondition(AddConditionArgs),
+
+    /// Add a branch step to a workflow
+    AddBranch(AddBranchArgs),
+
+    /// Convert a shell function to a workflow
+    ConvertFunction(ConvertFunctionArgs),
 
     /// Export commands and workflows to a file
     Export(ExportArgs),
@@ -46,39 +60,6 @@ pub enum Commands {
     Git(GitCommands),
 }
 
-#[derive(Subcommand, Debug)]
-pub enum FlowCommands {
-    /// Add a new workflow
-    Add(AddWorkflowArgs),
-
-    /// Run a stored workflow
-    Run(RunWorkflowArgs),
-
-    /// Remove a stored workflow
-    Remove(RemoveWorkflowArgs),
-
-    /// List all stored workflows
-    List(FlowListArgs),
-
-    /// Add a variable to a workflow
-    AddVar(AddWorkflowVarArgs),
-
-    /// Add a profile to a workflow
-    AddProfile(AddWorkflowProfileArgs),
-
-    /// List profiles for a workflow
-    ListProfiles(ListWorkflowProfilesArgs),
-
-    /// Add a conditional step to a workflow
-    AddCondition(AddConditionArgs),
-
-    /// Add a branch step to a workflow
-    AddBranch(AddBranchArgs),
-
-    /// Convert a shell function to a workflow
-    ConvertFunction(ConvertFunctionArgs),
-}
-
 #[derive(Args, Debug)]
 pub struct AddArgs {
     /// Name of the command
@@ -88,9 +69,13 @@ pub struct AddArgs {
     #[arg(short, long)]
     pub description: String,
 
-    /// The command to execute
-    #[arg(short, long)]
-    pub command: String,
+    /// The command to execute (for simple commands)
+    #[arg(short, long, conflicts_with = "steps_file")]
+    pub command: Option<String>,
+
+    /// Path to a JSON file containing workflow steps (for workflows)
+    #[arg(short = 'f', long, conflicts_with = "command")]
+    pub steps_file: Option<String>,
 
     /// Optional tags for categorization
     #[arg(short, long)]
@@ -101,6 +86,14 @@ pub struct AddArgs {
 pub struct RunArgs {
     /// Name of the command to run
     pub name: String,
+
+    /// Profile to use for variables (for workflows)
+    #[arg(short, long)]
+    pub profile: Option<String>,
+
+    /// Variable values in the format key=value (for workflows)
+    #[arg(short, long)]
+    pub var: Option<Vec<String>>,
 }
 
 #[derive(Args, Debug)]
@@ -119,53 +112,8 @@ pub struct ListArgs {
 }
 
 #[derive(Args, Debug)]
-pub struct FlowListArgs {
-    /// Filter workflows by tag
-    #[arg(short, long)]
-    pub tag: Option<String>,
-}
-
-#[derive(Args, Debug)]
 pub struct RemoveArgs {
     /// Name of the command to remove
-    pub name: String,
-}
-
-#[derive(Args, Debug)]
-pub struct AddWorkflowArgs {
-    /// Name of the workflow
-    pub name: String,
-
-    /// Description of the workflow
-    #[arg(short, long)]
-    pub description: String,
-
-    /// Path to a JSON file containing workflow steps
-    #[arg(short, long)]
-    pub steps_file: String,
-
-    /// Optional tags for categorization
-    #[arg(short, long)]
-    pub tags: Option<Vec<String>>,
-}
-
-#[derive(Args, Debug)]
-pub struct RunWorkflowArgs {
-    /// Name of the workflow to run
-    pub name: String,
-
-    /// Profile to use for variables
-    #[arg(short, long)]
-    pub profile: Option<String>,
-
-    /// Variable values in the format key=value
-    #[arg(short, long)]
-    pub var: Option<Vec<String>>,
-}
-
-#[derive(Args, Debug)]
-pub struct RemoveWorkflowArgs {
-    /// Name of the workflow to remove
     pub name: String,
 }
 
@@ -251,8 +199,8 @@ pub struct SetAiMaxTokensArgs {
 
 #[derive(Args, Debug)]
 pub struct AddWorkflowVarArgs {
-    /// Name of the workflow to add the variable to
-    pub workflow_name: String,
+    /// Name of the command/workflow to add the variable to
+    pub command_name: String,
 
     /// Name of the variable
     #[arg(short, long)]
@@ -273,8 +221,8 @@ pub struct AddWorkflowVarArgs {
 
 #[derive(Args, Debug)]
 pub struct AddWorkflowProfileArgs {
-    /// Name of the workflow to add the profile to
-    pub workflow_name: String,
+    /// Name of the command/workflow to add the profile to
+    pub command_name: String,
 
     /// Name of the profile
     #[arg(short, long)]
@@ -291,14 +239,14 @@ pub struct AddWorkflowProfileArgs {
 
 #[derive(Args, Debug)]
 pub struct ListWorkflowProfilesArgs {
-    /// Name of the workflow to list profiles for
-    pub workflow_name: String,
+    /// Name of the command/workflow to list profiles for
+    pub command_name: String,
 }
 
 #[derive(Args, Debug)]
 pub struct AddConditionArgs {
-    /// Name of the workflow to add the condition to
-    pub workflow_name: String,
+    /// Name of the command/workflow to add the condition to
+    pub command_name: String,
 
     /// Name of the conditional step
     #[arg(short, long)]
@@ -335,8 +283,8 @@ pub struct AddConditionArgs {
 
 #[derive(Args, Debug)]
 pub struct AddBranchArgs {
-    /// Name of the workflow to add the branch to
-    pub workflow_name: String,
+    /// Name of the command/workflow to add the branch to
+    pub command_name: String,
 
     /// Name of the branch step
     #[arg(short, long)]
@@ -361,8 +309,8 @@ pub struct AddBranchArgs {
 
 #[derive(Args, Debug)]
 pub struct ConvertFunctionArgs {
-    /// Name for the new workflow
-    pub workflow_name: String,
+    /// Name for the new command/workflow
+    pub command_name: String,
 
     /// Path to the shell script file containing the function
     #[arg(short, long)]

--- a/src/storage/git_storage.rs
+++ b/src/storage/git_storage.rs
@@ -188,6 +188,21 @@ impl GitIntegratedStorage {
         self.local_storage.update_command_usage(name)
     }
 
+    pub fn update_command(&self, command: &Command) -> Result<()> {
+        let result = self.local_storage.update_command(command);
+
+        // If successful, try to commit to repositories
+        if result.is_ok() {
+            if let Err(e) =
+                self.commit_changes_to_repositories(&format!("Update command: {}", command.name))
+            {
+                eprintln!("Warning: Failed to sync to git repositories: {}", e);
+            }
+        }
+
+        result
+    }
+
     pub fn add_workflow(&self, workflow: Workflow) -> Result<()> {
         let result = self.local_storage.add_workflow(workflow);
 

--- a/src/storage/store.rs
+++ b/src/storage/store.rs
@@ -183,6 +183,18 @@ impl Storage {
         }
     }
 
+    pub fn update_command(&self, command: &Command) -> Result<()> {
+        let mut store = self.load()?;
+
+        if store.commands.contains_key(&command.name) {
+            store.commands.insert(command.name.clone(), command.clone());
+            self.save(&store)?;
+            Ok(())
+        } else {
+            Err(ClixError::CommandNotFound(command.name.clone()))
+        }
+    }
+
     pub fn add_workflow(&self, workflow: Workflow) -> Result<()> {
         let mut store = self.load()?;
         store.workflows.insert(workflow.name.clone(), workflow);

--- a/tests/command_model_tests.rs
+++ b/tests/command_model_tests.rs
@@ -17,10 +17,14 @@ fn test_command_creation() {
 
     assert_eq!(command.name, name);
     assert_eq!(command.description, description);
-    assert_eq!(command.command, command_str);
+    assert_eq!(command.command, Some(command_str));
     assert_eq!(command.tags, tags);
     assert_eq!(command.use_count, 0);
     assert!(command.last_used.is_none());
+    assert_eq!(command.steps, None);
+    assert!(command.variables.is_empty());
+    assert!(command.profiles.is_empty());
+    assert!(!command.is_workflow());
 
     // Ensure created_at is reasonably close to now
     let now = SystemTime::now()


### PR DESCRIPTION
Remove the flow subcommand and unify command and workflow logic so that commands are workflows with a single step, as requested in issue #24.

Major changes:
- Remove 'flow' subcommand from CLI interface
- Update Command struct to optionally contain workflow steps
- Add workflow management commands directly to main CLI
- Update storage layer with update_command method
- Enhance run command to handle both simple commands and workflows
- Update AI integration for unified command structure
- Maintain backward compatibility during migration

Closes #24

Generated with [Claude Code](https://claude.ai/code)