### PR TITLE
Add snapshot and simple performance tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,6 +568,14 @@ Before submitting a pull request, please ensure:
 
 4. **Documentation is updated** if needed
 
+## Snapshot Testing and Benchmarking
+
+Snapshot tests verify CLI output using stored files. Benchmark tests check basic storage performance. Run them with the standard test command:
+```bash
+cargo nextest run
+```
+
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -568,9 +568,19 @@ Before submitting a pull request, please ensure:
 
 4. **Documentation is updated** if needed
 
-## Snapshot Testing and Benchmarking
+## Testing
 
-Snapshot tests verify CLI output using stored files. Benchmark tests check basic storage performance. Run them with the standard test command:
+### Snapshot Testing
+
+Snapshot tests ensure critical data formats remain stable. The project includes:
+
+- **Data Structure Snapshots**: Verify JSON export formats for commands and complex workflows remain consistent
+- **Export Serialization Tests**: Catch regressions in import/export functionality that teams rely on for sharing commands
+
+### Performance Testing
+
+Benchmark tests verify basic storage operations remain fast. Run all tests with:
+
 ```bash
 cargo nextest run
 ```

--- a/tests/cli_help_snapshot_tests.rs
+++ b/tests/cli_help_snapshot_tests.rs
@@ -1,0 +1,24 @@
+use clap::CommandFactory;
+use clix::cli::app::CliArgs;
+use std::fs;
+
+fn normalize(s: String) -> String {
+    s.lines().map(|l| l.trim()).collect::<Vec<_>>().join("\n")
+}
+
+#[test]
+fn cli_help_snapshot() {
+    let mut cmd = CliArgs::command();
+    cmd = cmd.term_width(120);
+    let mut buf = Vec::new();
+    cmd.write_long_help(&mut buf).unwrap();
+    let output_raw = String::from_utf8(buf).unwrap();
+    let truncated = output_raw.split("Options:").next().unwrap_or(&output_raw);
+    let help_output = normalize(truncated.to_string());
+
+    let expected = normalize(
+        fs::read_to_string("tests/snapshots/cli_help.txt").expect("Missing snapshot file"),
+    );
+
+    pretty_assertions::assert_eq!(expected, help_output);
+}

--- a/tests/data_structure_snapshot_tests.rs
+++ b/tests/data_structure_snapshot_tests.rs
@@ -1,8 +1,5 @@
-use clix::commands::models::{
-    Command, WorkflowStep, WorkflowVariable, Condition, BranchCase
-};
+use clix::commands::models::{BranchCase, Command, Condition, WorkflowStep, WorkflowVariable};
 use clix::share::export::{ExportData, ExportMetadata};
-use serde_json;
 use std::collections::HashMap;
 use std::fs;
 
@@ -133,7 +130,8 @@ fn workflow_export_serialization_snapshot() {
     };
 
     // Serialize to JSON
-    let json_output = serde_json::to_string_pretty(&export_data).expect("Failed to serialize export data");
+    let json_output =
+        serde_json::to_string_pretty(&export_data).expect("Failed to serialize export data");
     let normalized_output = normalize_json(&json_output);
 
     // Read expected snapshot - if it doesn't exist, write the output for manual inspection
@@ -143,8 +141,8 @@ fn workflow_export_serialization_snapshot() {
         panic!("Created new snapshot file: {}", snapshot_path);
     }
 
-    let expected = fs::read_to_string(snapshot_path)
-        .expect("Missing workflow export snapshot file");
+    let expected =
+        fs::read_to_string(snapshot_path).expect("Missing workflow export snapshot file");
     let normalized_expected = normalize_json(&expected);
 
     pretty_assertions::assert_eq!(normalized_expected, normalized_output);
@@ -176,7 +174,8 @@ fn simple_command_export_snapshot() {
         workflows: None,
     };
 
-    let json_output = serde_json::to_string_pretty(&export_data).expect("Failed to serialize export data");
+    let json_output =
+        serde_json::to_string_pretty(&export_data).expect("Failed to serialize export data");
     let normalized_output = normalize_json(&json_output);
 
     // Read expected snapshot - if it doesn't exist, write the output for manual inspection
@@ -186,8 +185,8 @@ fn simple_command_export_snapshot() {
         panic!("Created new snapshot file: {}", snapshot_path);
     }
 
-    let expected = fs::read_to_string(snapshot_path)
-        .expect("Missing simple command export snapshot file");
+    let expected =
+        fs::read_to_string(snapshot_path).expect("Missing simple command export snapshot file");
     let normalized_expected = normalize_json(&expected);
 
     pretty_assertions::assert_eq!(normalized_expected, normalized_output);

--- a/tests/data_structure_snapshot_tests.rs
+++ b/tests/data_structure_snapshot_tests.rs
@@ -1,0 +1,194 @@
+use clix::commands::models::{
+    Command, WorkflowStep, WorkflowVariable, Condition, BranchCase
+};
+use clix::share::export::{ExportData, ExportMetadata};
+use serde_json;
+use std::collections::HashMap;
+use std::fs;
+
+fn normalize_json(json: &str) -> String {
+    // Parse and re-serialize to normalize formatting
+    let value: serde_json::Value = serde_json::from_str(json).expect("Invalid JSON");
+    serde_json::to_string_pretty(&value).expect("Failed to serialize")
+}
+
+#[test]
+fn workflow_export_serialization_snapshot() {
+    // Create a complex workflow with conditionals, branches, and variables
+    let conditional_step = WorkflowStep::new_conditional(
+        "Environment Check".to_string(),
+        "Check if environment is valid".to_string(),
+        Condition {
+            expression: "[ \"$ENV\" = \"dev\" -o \"$ENV\" = \"staging\" ]".to_string(),
+            variable: None,
+        },
+        vec![WorkflowStep::new_command(
+            "Valid Environment".to_string(),
+            "echo \"Valid environment: $ENV\"".to_string(),
+            "Print valid environment".to_string(),
+            false,
+        )],
+        Some(vec![WorkflowStep::new_command(
+            "Invalid Environment".to_string(),
+            "echo \"Invalid environment: $ENV\" && exit 1".to_string(),
+            "Print error and exit".to_string(),
+            false,
+        )]),
+        None,
+    );
+
+    let branch_step = WorkflowStep::new_branch(
+        "Deploy by Environment".to_string(),
+        "Deploy based on environment type".to_string(),
+        "ENV".to_string(),
+        vec![
+            BranchCase {
+                value: "dev".to_string(),
+                steps: vec![WorkflowStep::new_command(
+                    "Dev Deploy".to_string(),
+                    "echo \"Deploying to dev\"".to_string(),
+                    "Deploy to development".to_string(),
+                    false,
+                )],
+            },
+            BranchCase {
+                value: "staging".to_string(),
+                steps: vec![WorkflowStep::new_command_with_approval(
+                    "Staging Deploy".to_string(),
+                    "echo \"Deploying to staging\"".to_string(),
+                    "Deploy to staging with approval".to_string(),
+                    false,
+                )],
+            },
+        ],
+        Some(vec![WorkflowStep::new_command(
+            "Default Deploy".to_string(),
+            "echo \"Unknown environment, using defaults\"".to_string(),
+            "Default deployment".to_string(),
+            true,
+        )]),
+    );
+
+    let mut workflow_command = Command::with_variables(
+        "complex-deploy".to_string(),
+        "Complex deployment workflow with conditionals and branches".to_string(),
+        vec![
+            conditional_step,
+            WorkflowStep::new_command(
+                "Pre-deploy".to_string(),
+                "echo \"Preparing deployment\"".to_string(),
+                "Prepare for deployment".to_string(),
+                false,
+            ),
+            branch_step,
+            WorkflowStep::new_command(
+                "Post-deploy".to_string(),
+                "echo \"Deployment complete\"".to_string(),
+                "Finalize deployment".to_string(),
+                false,
+            ),
+        ],
+        vec!["deployment".to_string(), "complex".to_string()],
+        vec![
+            WorkflowVariable::new(
+                "ENV".to_string(),
+                "Deployment environment (dev, staging, prod)".to_string(),
+                Some("dev".to_string()),
+                true,
+            ),
+            WorkflowVariable::new(
+                "VERSION".to_string(),
+                "Version to deploy".to_string(),
+                None,
+                false,
+            ),
+        ],
+    );
+    // Set fixed timestamp for predictable snapshots
+    workflow_command.created_at = 1684756234;
+
+    let mut simple_command = Command::new(
+        "hello".to_string(),
+        "Simple hello world command".to_string(),
+        "echo \"Hello, World!\"".to_string(),
+        vec!["example".to_string()],
+    );
+    // Set fixed timestamp for predictable snapshots
+    simple_command.created_at = 1684756234;
+
+    // Create export data structure
+    let mut commands = HashMap::new();
+    commands.insert("hello".to_string(), simple_command);
+    commands.insert("complex-deploy".to_string(), workflow_command);
+
+    let export_data = ExportData {
+        version: "0.1.0".to_string(),
+        metadata: ExportMetadata {
+            exported_at: 1684756234,
+            exported_by: "test-user".to_string(),
+            description: "Test export with complex workflow structures".to_string(),
+        },
+        commands: Some(commands),
+        workflows: None,
+    };
+
+    // Serialize to JSON
+    let json_output = serde_json::to_string_pretty(&export_data).expect("Failed to serialize export data");
+    let normalized_output = normalize_json(&json_output);
+
+    // Read expected snapshot - if it doesn't exist, write the output for manual inspection
+    let snapshot_path = "tests/snapshots/workflow_export.json";
+    if !std::path::Path::new(snapshot_path).exists() {
+        fs::write(snapshot_path, &normalized_output).expect("Failed to write snapshot");
+        panic!("Created new snapshot file: {}", snapshot_path);
+    }
+
+    let expected = fs::read_to_string(snapshot_path)
+        .expect("Missing workflow export snapshot file");
+    let normalized_expected = normalize_json(&expected);
+
+    pretty_assertions::assert_eq!(normalized_expected, normalized_output);
+}
+
+#[test]
+fn simple_command_export_snapshot() {
+    // Test simple command export structure
+    let mut command = Command::new(
+        "git-status".to_string(),
+        "Show git repository status".to_string(),
+        "git status --porcelain".to_string(),
+        vec!["git".to_string(), "status".to_string()],
+    );
+    // Set fixed timestamp for predictable snapshots
+    command.created_at = 1684756234;
+
+    let mut commands = HashMap::new();
+    commands.insert("git-status".to_string(), command);
+
+    let export_data = ExportData {
+        version: "0.1.0".to_string(),
+        metadata: ExportMetadata {
+            exported_at: 1684756234,
+            exported_by: "test-user".to_string(),
+            description: "Test export with simple command".to_string(),
+        },
+        commands: Some(commands),
+        workflows: None,
+    };
+
+    let json_output = serde_json::to_string_pretty(&export_data).expect("Failed to serialize export data");
+    let normalized_output = normalize_json(&json_output);
+
+    // Read expected snapshot - if it doesn't exist, write the output for manual inspection
+    let snapshot_path = "tests/snapshots/simple_command_export.json";
+    if !std::path::Path::new(snapshot_path).exists() {
+        fs::write(snapshot_path, &normalized_output).expect("Failed to write snapshot");
+        panic!("Created new snapshot file: {}", snapshot_path);
+    }
+
+    let expected = fs::read_to_string(snapshot_path)
+        .expect("Missing simple command export snapshot file");
+    let normalized_expected = normalize_json(&expected);
+
+    pretty_assertions::assert_eq!(normalized_expected, normalized_output);
+}

--- a/tests/performance_tests.rs
+++ b/tests/performance_tests.rs
@@ -1,0 +1,64 @@
+use clix::commands::Command;
+use clix::storage::Storage;
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::time::Instant;
+use test_context::{AsyncTestContext, test_context};
+
+struct PerfContext {
+    temp_dir: PathBuf,
+    storage: Storage,
+}
+
+impl AsyncTestContext for PerfContext {
+    fn setup<'a>() -> std::pin::Pin<Box<dyn std::future::Future<Output = Self> + Send + 'a>> {
+        Box::pin(async {
+            let temp_dir = std::env::temp_dir().join("clix_perf_test").join(format!(
+                "test_{}",
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_micros()
+            ));
+            fs::create_dir_all(&temp_dir).unwrap();
+            let clix_dir = temp_dir.join(".clix");
+            fs::create_dir_all(&clix_dir).unwrap();
+            let commands_file = clix_dir.join("commands.json");
+            fs::write(&commands_file, r#"{"commands":{},"workflows":{}}"#).unwrap();
+            unsafe {
+                env::set_var("HOME", &temp_dir);
+            }
+            let storage = Storage::new().unwrap();
+            PerfContext { temp_dir, storage }
+        })
+    }
+
+    fn teardown<'a>(self) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>> {
+        Box::pin(async move {
+            fs::remove_dir_all(&self.temp_dir).unwrap_or_default();
+        })
+    }
+}
+
+#[test_context(PerfContext)]
+#[tokio::test]
+async fn benchmark_add_commands(ctx: &mut PerfContext) {
+    let start = Instant::now();
+    for i in 0..100u32 {
+        let cmd = Command::new(
+            format!("cmd-{}", i),
+            "benchmark".to_string(),
+            "echo benchmark".to_string(),
+            vec![],
+        );
+        ctx.storage.add_command(cmd).unwrap();
+    }
+    let duration = start.elapsed();
+    println!("Added 100 commands in {:?}", duration);
+    assert!(
+        duration.as_secs_f32() < 1.0,
+        "adding commands took too long: {:?}",
+        duration
+    );
+}

--- a/tests/snapshots/cli_help.txt
+++ b/tests/snapshots/cli_help.txt
@@ -1,0 +1,23 @@
+A command-line tool for storing and executing developer workflows
+
+Usage: clix <COMMAND>
+
+Commands:
+  add               Add a new command
+  run               Run a stored command
+  list              List all stored commands and workflows
+  remove            Remove a stored command
+  add-var           Add a variable to a workflow
+  add-profile       Add a profile to a workflow
+  list-profiles     List profiles for a workflow
+  add-condition     Add a conditional step to a workflow
+  add-branch        Add a branch step to a workflow
+  convert-function  Convert a shell function to a workflow
+  export            Export commands and workflows to a file
+  import            Import commands and workflows from a file
+  ask               Ask Claude AI for help with creating and running commands
+  settings          Settings management commands
+  completions       Generate shell completions
+  git               Git repository management commands
+  help              Print this message or the help of the given subcommand(s)
+

--- a/tests/snapshots/simple_command_export.json
+++ b/tests/snapshots/simple_command_export.json
@@ -1,0 +1,26 @@
+{
+  "commands": {
+    "git-status": {
+      "command": "git status --porcelain",
+      "created_at": 1684756234,
+      "description": "Show git repository status",
+      "last_used": null,
+      "name": "git-status",
+      "profiles": {},
+      "steps": null,
+      "tags": [
+        "git",
+        "status"
+      ],
+      "use_count": 0,
+      "variables": []
+    }
+  },
+  "metadata": {
+    "description": "Test export with simple command",
+    "exported_at": 1684756234,
+    "exported_by": "test-user"
+  },
+  "version": "0.1.0",
+  "workflows": null
+}

--- a/tests/snapshots/workflow_export.json
+++ b/tests/snapshots/workflow_export.json
@@ -1,0 +1,158 @@
+{
+  "commands": {
+    "complex-deploy": {
+      "command": null,
+      "created_at": 1684756234,
+      "description": "Complex deployment workflow with conditionals and branches",
+      "last_used": null,
+      "name": "complex-deploy",
+      "profiles": {},
+      "steps": [
+        {
+          "command": "",
+          "conditional": {
+            "action": null,
+            "condition": {
+              "expression": "[ \"$ENV\" = \"dev\" -o \"$ENV\" = \"staging\" ]",
+              "variable": null
+            },
+            "else_block": {
+              "steps": [
+                {
+                  "command": "echo \"Invalid environment: $ENV\" && exit 1",
+                  "continue_on_error": false,
+                  "description": "Print error and exit",
+                  "name": "Invalid Environment",
+                  "require_approval": false,
+                  "step_type": "Command"
+                }
+              ]
+            },
+            "then_block": {
+              "steps": [
+                {
+                  "command": "echo \"Valid environment: $ENV\"",
+                  "continue_on_error": false,
+                  "description": "Print valid environment",
+                  "name": "Valid Environment",
+                  "require_approval": false,
+                  "step_type": "Command"
+                }
+              ]
+            }
+          },
+          "continue_on_error": false,
+          "description": "Check if environment is valid",
+          "name": "Environment Check",
+          "require_approval": false,
+          "step_type": "Conditional"
+        },
+        {
+          "command": "echo \"Preparing deployment\"",
+          "continue_on_error": false,
+          "description": "Prepare for deployment",
+          "name": "Pre-deploy",
+          "require_approval": false,
+          "step_type": "Command"
+        },
+        {
+          "branch": {
+            "cases": [
+              {
+                "steps": [
+                  {
+                    "command": "echo \"Deploying to dev\"",
+                    "continue_on_error": false,
+                    "description": "Deploy to development",
+                    "name": "Dev Deploy",
+                    "require_approval": false,
+                    "step_type": "Command"
+                  }
+                ],
+                "value": "dev"
+              },
+              {
+                "steps": [
+                  {
+                    "command": "echo \"Deploying to staging\"",
+                    "continue_on_error": false,
+                    "description": "Deploy to staging with approval",
+                    "name": "Staging Deploy",
+                    "require_approval": true,
+                    "step_type": "Command"
+                  }
+                ],
+                "value": "staging"
+              }
+            ],
+            "default_case": [
+              {
+                "command": "echo \"Unknown environment, using defaults\"",
+                "continue_on_error": true,
+                "description": "Default deployment",
+                "name": "Default Deploy",
+                "require_approval": false,
+                "step_type": "Command"
+              }
+            ],
+            "variable": "ENV"
+          },
+          "command": "",
+          "continue_on_error": false,
+          "description": "Deploy based on environment type",
+          "name": "Deploy by Environment",
+          "require_approval": false,
+          "step_type": "Branch"
+        },
+        {
+          "command": "echo \"Deployment complete\"",
+          "continue_on_error": false,
+          "description": "Finalize deployment",
+          "name": "Post-deploy",
+          "require_approval": false,
+          "step_type": "Command"
+        }
+      ],
+      "tags": [
+        "deployment",
+        "complex"
+      ],
+      "use_count": 0,
+      "variables": [
+        {
+          "default_value": "dev",
+          "description": "Deployment environment (dev, staging, prod)",
+          "name": "ENV",
+          "required": true
+        },
+        {
+          "default_value": null,
+          "description": "Version to deploy",
+          "name": "VERSION",
+          "required": false
+        }
+      ]
+    },
+    "hello": {
+      "command": "echo \"Hello, World!\"",
+      "created_at": 1684756234,
+      "description": "Simple hello world command",
+      "last_used": null,
+      "name": "hello",
+      "profiles": {},
+      "steps": null,
+      "tags": [
+        "example"
+      ],
+      "use_count": 0,
+      "variables": []
+    }
+  },
+  "metadata": {
+    "description": "Test export with complex workflow structures",
+    "exported_at": 1684756234,
+    "exported_by": "test-user"
+  },
+  "version": "0.1.0",
+  "workflows": null
+}


### PR DESCRIPTION
## Summary
- add snapshot test for CLI help output
- add simple performance test ensuring command addition is fast
- document snapshot and benchmark tests

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo nextest run`
